### PR TITLE
Forgiving timeout config (#25)

### DIFF
--- a/lib/gnuplot.ex
+++ b/lib/gnuplot.ex
@@ -75,8 +75,10 @@ defmodule Gnuplot do
   end
 
   defp timeout do
-    {t, :ms} = Application.get_env(:gnuplot, :timeout, {10_000, :ms})
-    t
+    case Application.get_env(:gnuplot, :timeout, {10_000, :ms}) do
+      {t, :ms} -> t
+      t when is_integer(t) -> t
+    end
   end
 
   @spec transmit(port(), list(Dataset.t())) :: :ok

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Gnuplot.MixProject do
   def project do
     [
       app: :gnuplot,
-      version: "1.22.267",
+      version: "1.22.268",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       description: "Interface between Elixir and Gnuplot graphing library",


### PR DESCRIPTION
Was experimenting with using a non-standard configuration of a tuple with a value and the units,
this also allows just a value which assumes they are milliseconds